### PR TITLE
add variable HELPDESK_DEFAULT_HTTP_PROTOCOL

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -275,13 +275,16 @@ def text_is_spam(text, request):
         from helpdesk.akismet import Akismet
     except:
         return False
+
+    from helpdesk import settings as helpdesk_settings
+    http_protocol = helpdesk_settings.HELPDESK_DEFAULT_HTTP_PROTOCOL
     try:
         site = Site.objects.get_current()
     except:
         site = Site(domain='configure-django-sites.com')
 
     ak = Akismet(
-        blog_url='http://%s/' % site.domain,
+        blog_url='%s://%s/' % (http_protocol, site.domain),
         agent='django-helpdesk',
     )
 

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -526,11 +526,14 @@ class Ticket(models.Model):
         """
         from django.contrib.sites.models import Site
         from django.core.urlresolvers import reverse
+        from helpdesk import settings as helpdesk_settings
+        http_protocol = helpdesk_settings.HELPDESK_DEFAULT_HTTP_PROTOCOL
         try:
             site = Site.objects.get_current()
         except:
             site = Site(domain='configure-django-sites.com')
-        return u"http://%s%s?ticket=%s&email=%s" % (
+        return u"%s://%s%s?ticket=%s&email=%s" % (
+            http_protocol,
             site.domain,
             reverse('helpdesk:public_view'),
             self.ticket_for_url,
@@ -545,11 +548,14 @@ class Ticket(models.Model):
         """
         from django.contrib.sites.models import Site
         from django.core.urlresolvers import reverse
+        from helpdesk import settings as helpdesk_settings
+        http_protocol = helpdesk_settings.HELPDESK_DEFAULT_HTTP_PROTOCOL
         try:
             site = Site.objects.get_current()
         except:
             site = Site(domain='configure-django-sites.com')
-        return u"http://%s%s" % (
+        return u"%s://%s%s" % (
+            http_protocol,
             site.domain,
             reverse('helpdesk:view',
                     args=[self.id])

--- a/helpdesk/settings.py
+++ b/helpdesk/settings.py
@@ -23,6 +23,16 @@ if not isinstance(DEFAULT_USER_SETTINGS, dict):
 
 HAS_TAG_SUPPORT = False
 
+# the protocol settings to be used for generating links (for example, a link to view a ticket)
+try:
+    HELPDESK_DEFAULT_HTTP_PROTOCOL = getattr(settings,
+                                             'HELPDESK_DEFAULT_HTTP_PROTOCOL').lower()
+except:
+    if getattr(settings, 'SECURE_SSL_REDIRECT'):
+        HELPDESK_DEFAULT_HTTP_PROTOCOL = 'https'
+    else:
+        HELPDESK_DEFAULT_HTTP_PROTOCOL = 'http'
+
 ##########################################
 # generic options - visible on all pages #
 ##########################################


### PR DESCRIPTION
If the variable HELPDESK_DEFAULT_HTTP_PROTOCOL ('http' or 'https') is explicitly specified, its value will be set to generate the links.
If the variable is not specified, the value is taken depending on the settings.SECURE_SSL_REDIRECT (if 'TRUE' is 'https', otherwise 'http')